### PR TITLE
CONSOLE|GIT: Safeprinting the console version and limiting the GIT de…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_SOURCE_DIR}/cmake/modules)
 
 # git describe
 include(GetGitRevisionDescription)
-git_describe(GIT_DESCRIBE --tags --always)
+git_describe(GIT_DESCRIBE --tags --always --abbrev=6)
 
 # MiniUPnPc
 if (USE_MINIUPNP)

--- a/client/src/c_console.cpp
+++ b/client/src/c_console.cpp
@@ -1317,7 +1317,7 @@ void C_DrawConsole()
 	{
 		// print the Odamex version in gold in the bottom right corner of console
 		char version_str[16];
-		sprintf(version_str, "%s (%s)", DOTVERSIONSTR, GitDescribe());
+		snprintf(version_str, sizeof(version_str), "%s (%s)", DOTVERSIONSTR, GitDescribe());
 		screen->PrintStr(primary_surface_width - 8 - C_StringWidth(version_str),
 					ConBottom - 12, version_str, CR_ORANGE);
 


### PR DESCRIPTION
…scribing to 6 characters.

6 characters is a norm for GIT revisionning projects.